### PR TITLE
fix potential  bug of column names in sql2pdb

### DIFF
--- a/pdb2sql/pdb2sql_base.py
+++ b/pdb2sql/pdb2sql_base.py
@@ -163,7 +163,8 @@ class pdb2sql_base(object):
         Returns:
             list: pdb-format lines
         """
-        data = self.get('*', **kwargs)
+        cols = ','.join(self.col.keys())
+        data = self.get(cols, **kwargs)
         pdb = []
         # the PDB format is pretty strict
         # http://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#ATOM


### PR DESCRIPTION
If the columns of SQL is updated or changed, the query `*` in `sql2pdb` will cause problem for outputing pdb. It's solved by query fixed column names.