### PR TITLE
[WIP] Many2SQL

### DIFF
--- a/pdb2sql/__init__.py
+++ b/pdb2sql/__init__.py
@@ -33,10 +33,12 @@ Example:
 Available modules:
     pdb2sql
         Core `pdb2sql` object
+    many2sql
+        Core `many2sql` object
     interface
         Core `interface` object
     StructureSimilarity
-        Tools tp compute structure similarities between two structures.
+        Tools to compute structure similarities between two structures.
     transform
         Tools to do structure transformation
     align
@@ -50,6 +52,7 @@ Utilities:
 """
 
 from .pdb2sqlcore import pdb2sql
+from .many2sql import many2sql
 from .interface import interface
 from .StructureSimilarity import StructureSimilarity
 from . import transform

--- a/pdb2sql/many2sql.py
+++ b/pdb2sql/many2sql.py
@@ -16,7 +16,8 @@ class many2sql(pdb2sql):
         """Create a sql dabase containing multiple pdbs."""
 
         if not isinstance(pdbfiles, list):
-            pdbfiles = [pdbfiles]
+            raise ValueError('pdbfiles must be a list')
+
         self.npdb = len(pdbfiles)
 
         self.tablenames = tablenames
@@ -25,7 +26,96 @@ class many2sql(pdb2sql):
             for i in range(1, self.npdb):
                 self.tablenames.append('ATOM'+str(i))
 
-        super().__init__(pdbfiles[0], tablename=tablenames[0])
+        super().__init__(pdbfiles[0], tablename=self.tablenames[0])
 
         for i in range(1, self.npdb):
-            self._create_table(pdfiles[i], tablename=tablenames[i])
+            self._create_table(
+                pdbfiles[i], tablename=self.tablenames[i])
+
+    def __call__(self, **kwargs):
+
+        names = self._get_table_names()
+
+        first = True
+        for n in names:
+            pdb_data = self.sql2pdb(tablename=n, **kwargs)
+            if first:
+                new_db = many2sql([pdb_data], tablenames=[n])
+                first = False
+            else:
+                new_db._create_table(pdb_data, tablename=n)
+
+        return new_db
+
+    def intersect(self, match=['name', 'resname', 'resSeq', 'chainID']):
+
+        all_data = self.get_intersection('*', match=match)
+        all_names = self._get_table_names()
+
+        first = True
+        for name, data in zip(all_names, all_data):
+            if first:
+                new_db = many2sql(
+                    [self.data2pdb(data)], tablenames=[name])
+                first = False
+            else:
+                new_db._create_table(
+                    self.data2pdb(data), tablename=name)
+
+        return new_db
+
+    def get_all(self, columns, **kwargs):
+
+        names = self._get_table_names()
+        data = []
+        for n in names:
+            data.append(self.get(columns, tablename=n, **kwargs))
+        return data
+
+    def get_intersection(self, column, match=['name', 'resname', 'resSeq', 'chainID']):
+
+        names = self._get_table_names()
+        ntable = len(names)
+        select = "select "
+
+        # column names
+        if column == '*':
+            column_list = list(self.col.keys())
+        else:
+            column_list = column.split(',')
+        ncol = len(column_list)
+
+        # fields to select
+        fields = ''
+        for n in names:
+            for c in column.split(','):
+                fields += n+'.'+c+', '
+        fields = fields[:-2]+' '
+
+        # join the table
+        from_join = 'from ' + ' INNER JOIN '.join(names) + ' '
+
+        # conditions
+        cond = 'on '
+        for attr in match:
+            for i1 in range(ntable-1):
+                table1 = names[i1]
+                for i2 in range(i1+1, ntable):
+                    table2 = names[i2]
+                    cond += table1+'.'+attr+'='+table2+'.'+attr+' and '
+        cond = cond[:-5]+';'
+        query = select+fields+from_join+cond
+        raw_data = self.conn.execute(query)
+
+        data = []
+        for i in range(ntable):
+            data.append([])
+
+        for x in raw_data:
+            for it in range(ntable):
+                s, e = it*ncol, (it+1)*ncol
+                data[it].append(list(x[s:e]))
+        return data
+
+#    [x for x in new.conn.execute("select ATOM.*, ATOM2.* from ATOM INNER JOIN ATOM2 on
+#    ATOM2.name=ATOM.name and ATOM2.resname=ATOM.resname and ATOM2.resSeq=ATOM.resSeq")]

--- a/pdb2sql/many2sql.py
+++ b/pdb2sql/many2sql.py
@@ -1,0 +1,31 @@
+import sqlite3
+import warnings
+import subprocess as sp
+import os
+import sys
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+from .pdb2sqlcore import pdb2sql
+
+
+class many2sql(pdb2sql):
+
+    def __init__(self, pdbfiles, tablenames=None):
+        """Create a sql dabase containing multiple pdbs."""
+
+        if not isinstance(pdbfiles, list):
+            pdbfiles = [pdbfiles]
+        self.npdb = len(pdbfiles)
+
+        self.tablenames = tablenames
+        if self.tablenames is None:
+            self.tablenames = ['ATOM']
+            for i in range(1, self.npdb):
+                self.tablenames.append('ATOM'+str(i))
+
+        super().__init__(pdbfiles[0], tablename=tablenames[0])
+
+        for i in range(1, self.npdb):
+            self._create_table(pdfiles[i], tablename=tablenames[i])

--- a/pdb2sql/many2sql.py
+++ b/pdb2sql/many2sql.py
@@ -13,7 +13,7 @@ from .pdb2sqlcore import pdb2sql
 class many2sql(pdb2sql):
 
     def __init__(self, pdbfiles, tablenames=None):
-        """Create a sql dabase containing multiple pdbs."""
+        """Create a sql database containing multiple pdbs."""
 
         if not isinstance(pdbfiles, list):
             raise ValueError('pdbfiles must be a list')
@@ -82,7 +82,7 @@ class many2sql(pdb2sql):
         """Returns the data from the selection of all table in the instance
 
         Args:
-            columns (str): column tame to return
+            columns (str): column name(s) to return
 
         Returns:
             list: data per structure

--- a/pdb2sql/many2sql.py
+++ b/pdb2sql/many2sql.py
@@ -26,11 +26,12 @@ class many2sql(pdb2sql):
             for i in range(1, self.npdb):
                 self.tablenames.append('ATOM'+str(i))
 
-        super().__init__(pdbfiles[0], tablename=self.tablenames[0])
+        super().__init__(self.convert_input(
+            pdbfiles[0]), tablename=self.tablenames[0])
 
         for i in range(1, self.npdb):
             self._create_table(
-                pdbfiles[i], tablename=self.tablenames[i])
+                self.convert_input(pdbfiles[i]), tablename=self.tablenames[i])
 
     def __call__(self, **kwargs):
         """Return a class instance containing the selection of each structure
@@ -51,6 +52,21 @@ class many2sql(pdb2sql):
                 new_db._create_table(pdb_data, tablename=n)
 
         return new_db
+
+    def convert_input(self, pdb):
+        """Converts the input in a format that pdb2sql accepts
+
+        Args:
+            pdb (str, list, pdb2sql): input data
+
+        Returns:
+            str, list: correct input
+        """
+
+        if isinstance(pdb, pdb2sql):
+            return pdb.sql2pdb()
+
+        return pdb
 
     def intersect(self, match=['name', 'resname', 'resSeq', 'chainID']):
         """Returns a many2sql instance containing the common part of all the structures.

--- a/pdb2sql/many2sql.py
+++ b/pdb2sql/many2sql.py
@@ -33,6 +33,11 @@ class many2sql(pdb2sql):
                 pdbfiles[i], tablename=self.tablenames[i])
 
     def __call__(self, **kwargs):
+        """Return a class instance containing the selection of each structure
+
+        Returns:
+            many2sql: class instance containing the selection of each structure
+        """
 
         names = self._get_table_names()
 
@@ -48,6 +53,15 @@ class many2sql(pdb2sql):
         return new_db
 
     def intersect(self, match=['name', 'resname', 'resSeq', 'chainID']):
+        """Returns a many2sql instance containing the common part of all the structures.
+
+        Args:
+            match (list, optional): column name that must match in the intersection.
+                                    Defaults to ['name', 'resname', 'resSeq', 'chainID'].
+
+        Returns:
+            many2sql: a class instance containing the tables of the matchin structure
+        """
 
         all_data = self.get_intersection('*', match=match)
         all_names = self._get_table_names()
@@ -65,6 +79,14 @@ class many2sql(pdb2sql):
         return new_db
 
     def get_all(self, columns, **kwargs):
+        """Returns the data from the selection of all table in the instance
+
+        Args:
+            columns (str): column tame to return
+
+        Returns:
+            list: data per structure
+        """
 
         names = self._get_table_names()
         data = []
@@ -73,7 +95,16 @@ class many2sql(pdb2sql):
         return data
 
     def get_intersection(self, column, match=['name', 'resname', 'resSeq', 'chainID']):
+        """Return the data of the interection
 
+        Args:
+            column (str): column table to return
+            match (list, optional): column name that must match in the intersection.
+                                    Defaults to ['name', 'resname', 'resSeq', 'chainID'].
+
+        Returns:
+            list: data per structure
+        """
         names = self._get_table_names()
         ntable = len(names)
         select = "select "
@@ -116,6 +147,3 @@ class many2sql(pdb2sql):
                 s, e = it*ncol, (it+1)*ncol
                 data[it].append(list(x[s:e]))
         return data
-
-#    [x for x in new.conn.execute("select ATOM.*, ATOM2.* from ATOM INNER JOIN ATOM2 on
-#    ATOM2.name=ATOM.name and ATOM2.resname=ATOM.resname and ATOM2.resSeq=ATOM.resSeq")]

--- a/pdb2sql/pdb2sql_base.py
+++ b/pdb2sql/pdb2sql_base.py
@@ -172,6 +172,17 @@ class pdb2sql_base(object):
         """
         cols = ','.join(self.col.keys())
         data = self.get(cols, tablename=tablename, **kwargs)
+        return self.data2pdb(data)
+
+    def data2pdb(self, data):
+        """converts data from a get method to a pdb
+
+        Args:
+            data (list): data from a get statement
+
+        Returns:
+            list: the formatted pdb data
+        """
         pdb = []
         # the PDB format is pretty strict
         # http://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#ATOM

--- a/pdb2sql/pdb2sql_base.py
+++ b/pdb2sql/pdb2sql_base.py
@@ -1,5 +1,6 @@
 import os
 
+
 class pdb2sql_base(object):
 
     def __init__(
@@ -78,15 +79,20 @@ class pdb2sql_base(object):
     def _create_sql(self):
         raise NotImplementedError()
 
+    def _get_table_names(self):
+        names = self.conn.execute(
+            "SELECT name from sqlite_master WHERE type='table';")
+        return [n[0] for n in names]
+
     # get the properties
     def get(self, atnames, **kwargs):
         raise NotImplementedError()
 
-    def get_xyz(self, **kwargs):
+    def get_xyz(self, tablename='atom', **kwargs):
         """Shortcut to get the xyz coordinates."""
-        return self.get('x,y,z', **kwargs)
+        return self.get('x,y,z', tablename=tablename, **kwargs)
 
-    def get_residues(self, **kwargs):
+    def get_residues(self, tablename='atom', **kwargs):
         """Get the residue sequence.
 
         Returns:
@@ -96,10 +102,11 @@ class pdb2sql_base(object):
             >>> db.get_residues()
         """
 
-        res = [tuple(x) for x in self.get('chainID,resName,resSeq', **kwargs)]
+        res = [tuple(x) for x in self.get(
+            'chainID,resName,resSeq', tablename=tablename, **kwargs)]
         return sorted(set(res), key=res.index)
 
-    def get_chains(self, **kwargs):
+    def get_chains(self, tablename='atom', **kwargs):
         """Get the chain IDs.
 
         Returns:
@@ -108,13 +115,13 @@ class pdb2sql_base(object):
         Examples:
             >>> db.get_chains()
         """
-        chains = self.get('chainID', **kwargs)
+        chains = self.get('chainID', tablename=tablename, **kwargs)
         return sorted(set(chains))
 
     def update(self, attribute, values, **kwargs):
         raise NotImplementedError()
 
-    def update_xyz(self, xyz, **kwargs):
+    def update_xyz(self, xyz, tablename='atom',  **kwargs):
         """Update the xyz coordinates."""
         self.update('x,y,z', xyz, **kwargs)
 
@@ -126,7 +133,7 @@ class pdb2sql_base(object):
         """Add a new column to the ATOM table."""
         raise NotImplementedError()
 
-    def exportpdb(self, fname, append=False, **kwargs):
+    def exportpdb(self, fname, append=False, tablename='atom', **kwargs):
         """Export a PDB file.
 
         Args:
@@ -144,13 +151,13 @@ class pdb2sql_base(object):
         else:
             f = open(fname, 'w')
 
-        lines = self.sql2pdb(**kwargs)
+        lines = self.sql2pdb(tablename=tablename, **kwargs)
         for i in lines:
             f.write(i + '\n')
 
         f.close()
 
-    def sql2pdb(self, **kwargs):
+    def sql2pdb(self, tablename='atom', **kwargs):
         """Convert SQL data to PDB formatted lines.
 
         Args:
@@ -164,7 +171,7 @@ class pdb2sql_base(object):
             list: pdb-format lines
         """
         cols = ','.join(self.col.keys())
-        data = self.get(cols, **kwargs)
+        data = self.get(cols, tablename=tablename, **kwargs)
         pdb = []
         # the PDB format is pretty strict
         # http://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#ATOM

--- a/pdb2sql/pdb2sqlcore.py
+++ b/pdb2sql/pdb2sqlcore.py
@@ -58,7 +58,9 @@ class pdb2sql(pdb2sql_base):
         names = self._get_table_names()
         if len(names) > 1:
             warnings.warn('pdbsql is meant for single structure. \
-                          To use multiple structure use many2sql')
+                          To use multiple structures use many2sql. \
+                          This call will only return the data of \
+                          the first table : ', names[0])
 
         pdb_data = self.sql2pdb(tablename=names[0], **kwargs)
         new_db = pdb2sql(pdb_data, tablename=names[0])
@@ -335,7 +337,6 @@ class pdb2sql(pdb2sql_base):
         Examples:
             >>> db.get_colnames()
         """
-
         tablename = self._get_table_names()[0]
         cd = self.conn.execute(
             'select * from {tablename}'.format(tablename=tablename))

--- a/pdb2sql/pdb2sqlcore.py
+++ b/pdb2sql/pdb2sqlcore.py
@@ -351,7 +351,7 @@ class pdb2sql(pdb2sql_base):
             >>> db.print_colnames()
         """
         tablenames = self._get_table_names()
-        names = self.get_colnames(tablename=tablenames[0])
+        names = self.get_colnames()
         print('Possible column names are:')
         for n in names:
             print('\t' + n)

--- a/pdb2sql/pdb2sqlcore.py
+++ b/pdb2sql/pdb2sqlcore.py
@@ -12,7 +12,7 @@ from .pdb2sql_base import pdb2sql_base
 
 class pdb2sql(pdb2sql_base):
 
-    def __init__(self, pdbfile, **kwargs):
+    def __init__(self, pdbfile, tablename='atom', **kwargs):
         """Create a SQL database with PDB data.
 
         Notes:
@@ -29,6 +29,7 @@ class pdb2sql(pdb2sql_base):
 
         # create the database
         self._create_sql()
+        self._create_table(pdbfile, tablename=tablename)
 
         # fix the chain ID
         if self.fix_chainID:
@@ -47,28 +48,32 @@ class pdb2sql(pdb2sql_base):
                     - no_chainID = ['A']
 
         Returns:
-            pdb2sql: an pb2sql instance 
+            pdb2sql: an pb2sql instance
 
         Examples:
             >>> sqldb pdb2sql('1AK4.pdb')
             >>> dbA = sqldb(chainID='A')
         """
-        pdb_data = self.sql2pdb(**kwargs)
-        return pdb2sql(pdb_data)
+
+        names = self._get_table_names()
+
+        for iN, n in enumerate(names):
+            pdb_data = self.sql2pdb(tablename=n, **kwargs)
+            if iN == 0:
+                new_db = pdb2sql(pdb_data, tablename=n)
+            else:
+                new_db._create_table(pdb_data, tablename=n)
+        return new_db
 
     def __repr__(self):
         return f'{self.__module__}.{self.__class__.__name__} object'
 
-    def _create_sql(self):
+    def _create_sql(self, tablename='ATOM'):
         """Create a sql database containg a model PDB."""
-        pdbfile = self.pdbfile
         sqlfile = self.sqlfile
 
         if self.verbose:
             print('-- Create SQLite3 database')
-
-        # size of the things
-        ncol = len(self.col)
 
         # open the data base
         # if we do not specify a db name
@@ -83,6 +88,11 @@ class pdb2sql(pdb2sql_base):
             self.conn = sqlite3.connect(sqlfile)
         self.c = self.conn.cursor()
 
+    def _create_table(self, pdbfile, tablename='ATOM'):
+
+        # size of the things
+        ncol = len(self.col)
+
         # intialize the header/placeholder
         header, qm = '', ''
         for ic, (colname, coltype) in enumerate(self.col.items()):
@@ -93,7 +103,8 @@ class pdb2sql(pdb2sql_base):
                 qm += ','
 
         # create the table
-        query = 'CREATE TABLE ATOM ({hd})'.format(hd=header)
+        query = 'CREATE TABLE {tablename} ({hd})'.format(tablename=tablename,
+                                                         hd=header)
         self.c.execute(query)
 
         # get pdb data
@@ -157,8 +168,8 @@ class pdb2sql(pdb2sql_base):
 
         # push in the database
         self.c.executemany(
-            'INSERT INTO ATOM VALUES ({qm})'.format(
-                qm=qm), data_atom)
+            'INSERT INTO {tablename} VALUES ({qm})'.format(tablename=tablename,
+                                                           qm=qm), data_atom)
 
     @staticmethod
     def read_pdb(pdbfile):
@@ -311,7 +322,7 @@ class pdb2sql(pdb2sql_base):
 
     # get the names of the columns
 
-    def get_colnames(self):
+    def get_colnames(self, tablename='atom'):
         """Get SQL column names.
 
         Returns:
@@ -321,7 +332,8 @@ class pdb2sql(pdb2sql_base):
             >>> db.get_colnames()
         """
 
-        cd = self.conn.execute('select * from atom')
+        cd = self.conn.execute(
+            'select * from {tablename}'.format(tablename=tablename))
         names = list(map(lambda x: x[0], cd.description))
         names = ['rowID'] + names
         return names
@@ -337,7 +349,7 @@ class pdb2sql(pdb2sql_base):
         for n in names:
             print('\t' + n)
 
-    def print(self, columns='*', **kwargs):
+    def print(self, columns='*', tablename='atom', **kwargs):
         """Print out SQL ATOM table.
 
         Notes:
@@ -362,7 +374,7 @@ class pdb2sql(pdb2sql_base):
         Examples:
             >>> db.print()
         """
-        data = self.get(columns, **kwargs)
+        data = self.get(columns, tablename=tablename, ** kwargs)
         arr = np.array(data)
 
         if len(arr.shape) == 2:
@@ -372,7 +384,8 @@ class pdb2sql(pdb2sql_base):
             df = pd.DataFrame(arr)
 
         if columns == '*':
-            cd = self.conn.execute('select * from atom')
+            cd = self.conn.execute(
+                'select * from {tablename}'.format(tablename=tablename))
             names = list(map(lambda x: x[0], cd.description))
             df.columns = names
         else:
@@ -381,7 +394,7 @@ class pdb2sql(pdb2sql_base):
         print(df.to_csv(sep='\t', index=False))
 
     # get the properties
-    def get(self, columns, **kwargs):
+    def get(self, columns, tablename='ATOM', **kwargs):
         """Exectute simple SQL query to extract values.
 
         Args:
@@ -429,7 +442,8 @@ class pdb2sql(pdb2sql_base):
 
         # if we have 0 key we take the entire db
         if len(kwargs) == 0:
-            query = 'SELECT {an} FROM ATOM'.format(an=columns)
+            query = 'SELECT {an} FROM {tablename}'.format(
+                an=columns, tablename=tablename)
             data = [list(row) for row in self.c.execute(query)]
 
         #######################################################################
@@ -450,15 +464,16 @@ class pdb2sql(pdb2sql_base):
 
                 try:
                     self.c.execute(
-                        "SELECT EXISTS(SELECT {an} FROM ATOM)".format(
-                            an=k))
+                        "SELECT EXISTS(SELECT {an} FROM {tablename})".format(
+                            an=k, tablename=tablename))
                 except BaseException:
                     raise ValueError(
                         f'Invalid column name {k}. Possible names are\n'
                         f'{self.get_colnames()}')
 
             # form the query and the tuple value
-            query = 'SELECT {an} FROM ATOM WHERE '.format(an=columns)
+            query = 'SELECT {an} FROM {tablename} WHERE '.format(
+                an=columns, tablename=tablename)
             conditions = []
             vals = ()
 
@@ -563,7 +578,7 @@ class pdb2sql(pdb2sql_base):
 
         return data
 
-    def update(self, columns, values, **kwargs):
+    def update(self, columns, values, tablename='ATOM', **kwargs):
         """Update the database with given values.
 
         Args:
@@ -628,7 +643,7 @@ class pdb2sql(pdb2sql_base):
                 'Number of data values incompatible with the given conditions')
 
         # prepare the query
-        query = 'UPDATE ATOM SET '
+        query = 'UPDATE {tablename} SET '.format(tablename=tablename)
         query = query + ', '.join(map(lambda x: x + '=?', columns))
         query = query + ' WHERE rowID=?'
 
@@ -645,7 +660,7 @@ class pdb2sql(pdb2sql_base):
 
         self.c.executemany(query, data)
 
-    def update_column(self, colname, values, index=None):
+    def update_column(self, colname, values, index=None, tablename='ATOM'):
         """Update a single column.
 
         Args:
@@ -664,11 +679,11 @@ class pdb2sql(pdb2sql_base):
         else:
             data = [[v, ind + 1] for v, ind in zip(values, index)]
 
-        query = 'UPDATE ATOM SET {cn}=? WHERE rowID=?'.format(
-            cn=colname)
+        query = 'UPDATE {tablename} SET {cn}=? WHERE rowID=?'.format(tablename=tablename,
+                                                                     cn=colname)
         self.c.executemany(query, data)
 
-    def add_column(self, colname, coltype='FLOAT', value=0):
+    def add_column(self, colname, coltype='FLOAT', value=0, tablename='ATOM'):
         """Add an new column to the ATOM table with same value for each row.
 
         Args:
@@ -681,8 +696,8 @@ class pdb2sql(pdb2sql_base):
             >>> db.add_column('id', coltype='str', value='positive')
         """
 
-        query = "ALTER TABLE ATOM ADD COLUMN '%s' %s DEFAULT %s" % (
-            colname, coltype, str(value))
+        query = "ALTER TABLE %s ADD COLUMN '%s' %s DEFAULT %s" % (tablename,
+                                                                  colname, coltype, str(value))
         self.c.execute(query)
 
     def _commit(self):

--- a/pdb2sql/pdb2sqlcore.py
+++ b/pdb2sql/pdb2sqlcore.py
@@ -93,6 +93,10 @@ class pdb2sql(pdb2sql_base):
         # size of the things
         ncol = len(self.col)
 
+        # clean up tablename
+        for c in "!@#$%^&*()[]{};:,./<>?\|`~-=_+":
+            tablename = tablename.replace(c, '_')
+
         # intialize the header/placeholder
         header, qm = '', ''
         for ic, (colname, coltype) in enumerate(self.col.items()):
@@ -322,7 +326,7 @@ class pdb2sql(pdb2sql_base):
 
     # get the names of the columns
 
-    def get_colnames(self, tablename='atom'):
+    def get_colnames(self):
         """Get SQL column names.
 
         Returns:
@@ -332,6 +336,7 @@ class pdb2sql(pdb2sql_base):
             >>> db.get_colnames()
         """
 
+        tablename = self._get_table_names()[0]
         cd = self.conn.execute(
             'select * from {tablename}'.format(tablename=tablename))
         names = list(map(lambda x: x[0], cd.description))
@@ -344,7 +349,8 @@ class pdb2sql(pdb2sql_base):
         Examples:
             >>> db.print_colnames()
         """
-        names = self.get_colnames()
+        tablenames = self._get_table_names()
+        names = self.get_colnames(tablename=tablenames[0])
         print('Possible column names are:')
         for n in names:
             print('\t' + n)
@@ -417,6 +423,7 @@ class pdb2sql(pdb2sql_base):
         Examples:
             >>> db.get('x,y,z', chainID=['A'], no_resName=['ALA', 'TRP'])
         """
+
         # check arguments format
         valid_colnames = self.get_colnames()
 

--- a/pdb2sql/pdb2sqlcore.py
+++ b/pdb2sql/pdb2sqlcore.py
@@ -56,13 +56,13 @@ class pdb2sql(pdb2sql_base):
         """
 
         names = self._get_table_names()
+        if len(names) > 1:
+            warnings.warn('pdbsql is meant for single structure. \
+                          To use multiple structure use many2sql')
 
-        for iN, n in enumerate(names):
-            pdb_data = self.sql2pdb(tablename=n, **kwargs)
-            if iN == 0:
-                new_db = pdb2sql(pdb_data, tablename=n)
-            else:
-                new_db._create_table(pdb_data, tablename=n)
+        pdb_data = self.sql2pdb(tablename=names[0], **kwargs)
+        new_db = pdb2sql(pdb_data, tablename=names[0])
+
         return new_db
 
     def __repr__(self):

--- a/pdb2sql/pdb2sqlcore.py
+++ b/pdb2sql/pdb2sqlcore.py
@@ -51,7 +51,7 @@ class pdb2sql(pdb2sql_base):
             pdb2sql: an pb2sql instance
 
         Examples:
-            >>> sqldb pdb2sql('1AK4.pdb')
+            >>> sqldb = pdb2sql('1AK4.pdb')
             >>> dbA = sqldb(chainID='A')
         """
 
@@ -374,7 +374,7 @@ class pdb2sql(pdb2sql_base):
         Examples:
             >>> db.print()
         """
-        data = self.get(columns, tablename=tablename, ** kwargs)
+        data = self.get(columns, tablename=tablename, **kwargs)
         arr = np.array(data)
 
         if len(arr.shape) == 2:

--- a/pdb2sql/superpose.py
+++ b/pdb2sql/superpose.py
@@ -2,6 +2,7 @@
 import os
 import numpy as np
 from .pdb2sqlcore import pdb2sql
+from .many2sql import many2sql
 from .transform import rotate
 
 
@@ -40,26 +41,36 @@ def superpose(mobile, target, method='svd', only_backbone=True, export=True, **k
         if 'name' not in kwargs:
             kwargs['name'] = backbone_atoms
         else:
-            raise ValueError('Atom type specified but only_backbone == True')
+            raise ValueError(
+                'Atom type specified but only_backbone == True')
 
     # selections of some atoms
     selection_mobile = np.array(sql_mobile.get("x,y,z", **kwargs))
     selection_target = np.array(sql_target.get("x,y,z", **kwargs))
+
+    # deal with the cases where some res are missing/added
+    if len(selection_mobile) != len(selection_target):
+        warnings.warn(
+            'selection have different size, getting intersection')
+        selection_mobile, selection_target = get_intersection(
+            sql_mobile, sql_target, **kwargs)
 
     # the molbile original coordinates
     xyz_mobile = np.array(sql_mobile.get("x,y,z"))
 
     # transform the xyz mobile
     xyz_mobile = superpose_selection(xyz_mobile,
-                                    selection_mobile, selection_target, method)
+                                     selection_mobile, selection_target, method)
 
     # update the sql
     sql_mobile.update('x,y,z', xyz_mobile)
 
     # export a pdb file
     if export:
-        target_name = os.path.basename(sql_target.pdbfile).rstrip('.pdb')
-        mobile_name = os.path.basename(sql_mobile.pdbfile).rstrip('.pdb')
+        target_name = os.path.basename(
+            sql_target.pdbfile).rstrip('.pdb')
+        mobile_name = os.path.basename(
+            sql_mobile.pdbfile).rstrip('.pdb')
         fname = mobile_name + '_superposed_on_' + \
             target_name + '.pdb'
         sql_mobile.exportpdb(fname)
@@ -276,3 +287,17 @@ def get_rotation_matrix_quaternion(P, Q):
     U[2, 2] = q0**2 - q1**2 - q2**2 + q3**2
 
     return U
+
+
+def get_intersection(db1, db2, **kwargs):
+    """Get the xyz of the intersection between db1 and db2
+
+    Args:
+        db1 (pdb2sql): pdbsql of the first complex
+        db2 (pdb2sql): pdb2sql of the second complex
+    """
+    pdbdata = [db1.sql2pdb(), db2.sql2pdb()]
+    manydb = many2sql(pdbdata)
+
+    data = manydb(**kwargs).get_intersection('x,y,z')
+    return np.array(data[0]), np.array(data[1])

--- a/test/test_many2sql.py
+++ b/test/test_many2sql.py
@@ -1,0 +1,62 @@
+import unittest
+import os
+import numpy as np
+from pathlib import Path
+from pdb2sql import many2sql
+from pdb2sql import pdb2sql
+from utils import CaptureOutErr
+
+
+class TestMany2SQL(unittest.TestCase):
+
+    def setUp(self):
+        self.pdb1 = 'pdb/1AK4/1AK4_5w.pdb'
+        self.pdb2 = 'pdb/1AK4/1AK4_10w.pdb'
+
+    def test_init_from_files(self):
+        """Verify init from path."""
+        pdbs = [self.pdb1, self.pdb2]
+        many = many2sql(pdbs, tablenames=pdbs)
+
+    def test_init_from_pdb_data(self):
+        """Verify init from data."""
+        pdbs = [self.pdb1, self.pdb2]
+        sqls = [pdb2sql(p) for p in pdbs]
+        data = [db.sql2pdb() for db in sqls]
+        many = many2sql(data, tablenames=pdbs)
+
+    def test_init_from_sql(self):
+        """Verify default sqls."""
+        pdbs = [self.pdb1, self.pdb2]
+        sqls = [pdb2sql(p) for p in pdbs]
+        many = many2sql(sqls, tablenames=pdbs)
+
+    def test_call(self):
+        """Test call function."""
+        pdbs = [self.pdb1, self.pdb2]
+        many = many2sql(pdbs, tablenames=pdbs)
+        chainA = many(chainID='A')
+
+    def test_get_all(self):
+        """Test get_all function."""
+        pdbs = [self.pdb1, self.pdb2]
+        many = many2sql(pdbs, tablenames=pdbs)
+        data = many.get_all('x,y,z', chainID='A')
+
+    def test_get_intersection(self):
+        """Test get_all function."""
+        pdbs = [self.pdb1, self.pdb2]
+        many = many2sql(pdbs, tablenames=pdbs)
+        data = many.get_intersection('x,y,z')
+
+    def test_intersect(self):
+        """Test get_all function."""
+        pdbs = [self.pdb1, self.pdb2]
+        many = many2sql(pdbs, tablenames=pdbs)
+        chainA = many.intersect()
+
+
+if __name__ == '__main__':
+    # runner = unittest.TextTestRunner(verbosity=2)
+    # unittest.main(testRunner=runner)
+    unittest.main()


### PR DESCRIPTION
Added a `many2sql` class  that allows to have multiple pdb files in the same database under different tables. Using this we can easily obtain the intersection between the different tables, i.e. extract the common part of the different structures contained in the database. 

Many changes happened under `pdb2sql` so that we can easily use it as a super class for `many2pdb` 

The `superpose` function now checks that the selection have identical length and if they don't use a `many2sql` to get the intersection between the two structures.