### PR TITLE
Add Paths to test folder

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,5 @@
+"""Init module for tests package."""
+from pathlib import Path
+
+test_folder = Path(__file__).resolve().parent
+pdb_folder = Path(test_folder, 'pdb')

--- a/test/test_align.py
+++ b/test/test_align.py
@@ -1,13 +1,17 @@
 import unittest
+from pathlib import Path
 from pdb2sql.align import align, pca, align_interface
 import numpy as np
+
+
+from . import pdb_folder
 
 
 class TestAlign(unittest.TestCase):
     """Test the superpose functionality"""
 
     def setUp(self):
-        self.pdb = 'pdb/1AK4/1AK4_10w.pdb'
+        self.pdb = Path(pdb_folder, '1AK4', '1AK4_10w.pdb')
 
     def test_align(self):
         """Test align()"""

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -1,13 +1,16 @@
 import unittest
+from pathlib import Path
 from pdb2sql import interface
 from pdb2sql import pdb2sql
+
+from . import pdb_folder
 
 
 class Test_1_ContactAtoms(unittest.TestCase):
     """Test function get_contact_atoms."""
 
     def setUp(self):
-        self.pdb = 'pdb/3CRO.pdb'
+        self.pdb = Path(pdb_folder, '3CRO.pdb')
         self.db = interface(self.pdb)
 
     def test_get_contact_atoms_default(self):
@@ -93,7 +96,7 @@ class Test_1_ContactAtoms(unittest.TestCase):
 
     def test_get_contact_atoms_exludeH(self):
         """"verify get_contact_atoms(excludeH=True)"""
-        pdb = 'pdb/3CRO_H.pdb'
+        pdb = Path(pdb_folder, '3CRO_H.pdb')
         db = interface(pdb)
         contact_atoms = db.get_contact_atoms(excludeH=True)
         self.assertIsInstance(contact_atoms, dict)
@@ -119,7 +122,7 @@ class Test_1_ContactAtoms(unittest.TestCase):
 
     def test_get_contact_atoms_alltrue(self):
         """"verify get_contact_atoms(True)"""
-        pdb = 'pdb/3CRO_H.pdb'
+        pdb = Path(pdb_folder, '3CRO_H.pdb')
         db = interface(pdb)
         with self.assertWarns(UserWarning) as ex:
             contact_atoms = db.get_contact_atoms(
@@ -144,7 +147,7 @@ class Test_2_ContactResidues(unittest.TestCase):
     """test get_contact_residues function."""
 
     def setUp(self):
-        self.pdb = 'pdb/3CRO.pdb'
+        self.pdb = Path(pdb_folder, '3CRO.pdb')
         self.db = interface(self.pdb)
 
     def test_get_contact_residues_default(self):
@@ -193,7 +196,7 @@ class Test_2_ContactResidues(unittest.TestCase):
 
     def test_get_contact_residues_exludeH(self):
         """"verify get_contact_residues(excludeH=True)"""
-        pdb = 'pdb/3CRO_H.pdb'
+        pdb = Path(pdb_folder, '3CRO_H.pdb')
         db = interface(pdb)
         contact_residues = db.get_contact_residues(
             allchains=True, excludeH=True)
@@ -253,7 +256,7 @@ class Test_2_ContactResidues(unittest.TestCase):
 
     def test_get_contact_residues_alltrue(self):
         """"verify get_contact_residues(True)"""
-        pdb = 'pdb/3CRO_H.pdb'
+        pdb = Path(pdb_folder, '3CRO_H.pdb')
         db = interface(pdb)
         with self.assertWarns(UserWarning) as ex:
             contact_residues = db.get_contact_residues(
@@ -273,7 +276,7 @@ class Test_3_PDB2SQLInstanceInput(unittest.TestCase):
     """test using pdb2sql instance as input"""
 
     def setUp(self):
-        self.pdb = 'pdb/3CRO.pdb'
+        self.pdb = Path(pdb_folder, '3CRO.pdb')
 
     def test_get_contact_residues_default(self):
         """"verify get_contact_residues default."""

--- a/test/test_many2sql.py
+++ b/test/test_many2sql.py
@@ -4,14 +4,16 @@ import numpy as np
 from pathlib import Path
 from pdb2sql import many2sql
 from pdb2sql import pdb2sql
-from utils import CaptureOutErr
+
+from .utils import CaptureOutErr
+from . import pdb_folder
 
 
 class TestMany2SQL(unittest.TestCase):
 
     def setUp(self):
-        self.pdb1 = 'pdb/1AK4/1AK4_5w.pdb'
-        self.pdb2 = 'pdb/1AK4/1AK4_10w.pdb'
+        self.pdb1 = os.fspath(Path(pdb_folder, '1AK4', '1AK4_5w.pdb'))
+        self.pdb2 = os.fspath(Path(pdb_folder, '1AK4', '1AK4_10w.pdb'))
 
     def test_init_from_files(self):
         """Verify init from path."""

--- a/test/test_pdb2sqlcore.py
+++ b/test/test_pdb2sqlcore.py
@@ -3,21 +3,23 @@ import os
 import numpy as np
 from pathlib import Path
 from pdb2sql import pdb2sql
-from utils import CaptureOutErr
+
+from .utils import CaptureOutErr
+from . import pdb_folder, test_folder
 
 
 class TestCreateSQL(unittest.TestCase):
 
     def setUp(self):
-        self.pdbfile = "./pdb/3CRO.pdb"
-        self.sqlfile = "./sql_3CRO.db"
+        self.pdbfile = Path(pdb_folder, "3CRO.pdb")
+        self.sqlfile = Path(test_folder, "sql_3CRO.db")
 
-        self.pdb_longline = "./pdb/dummy_longline.pdb"
-        self.pdb_nochainID_segID = "./pdb/dummy_blank_chainID_with_segID.pdb"
-        self.pdb_nochainID_nosegID = "./pdb/dummy_blank_chainID_without_segID.pdb"
-        self.pdb_noocc = "./pdb/dummy_blank_occupancy.pdb"
-        self.pdb_notemp = "./pdb/dummy_blank_temperature.pdb"
-        self.pdb_noelement = "./pdb/dummy_blank_element.pdb"
+        self.pdb_longline = Path(pdb_folder, "dummy_longline.pdb")
+        self.pdb_nochainID_segID = Path(pdb_folder, "dummy_blank_chainID_with_segID.pdb")
+        self.pdb_nochainID_nosegID = Path(pdb_folder, "dummy_blank_chainID_without_segID.pdb")
+        self.pdb_noocc = Path(pdb_folder, "dummy_blank_occupancy.pdb")
+        self.pdb_notemp = Path(pdb_folder, "dummy_blank_temperature.pdb")
+        self.pdb_noelement = Path(pdb_folder, "dummy_blank_element.pdb")
 
     def test_init(self):
         """Verify default init."""
@@ -231,7 +233,7 @@ class TestCreateSQL(unittest.TestCase):
 
 class TestPrintGetUpdate(unittest.TestCase):
     def setUp(self):
-        pdbfile = "./pdb/dummy_template.pdb"
+        pdbfile = Path(pdb_folder, "dummy_template.pdb")
         self.db = pdb2sql(pdbfile)
 
     def test_print(self):

--- a/test/test_structureSimilarity.py
+++ b/test/test_structureSimilarity.py
@@ -1,16 +1,18 @@
 import os
+from pathlib import Path
 from pdb2sql.StructureSimilarity import StructureSimilarity
 import unittest
 
+from . import pdb_folder
 
 class TestSim(unittest.TestCase):
     """Test Similarity calculation."""
 
     def setUp(self):
-        self.decoy = 'pdb/1AK4/1AK4_5w.pdb'
-        self.ref = 'pdb/1AK4/target.pdb'
-        self.izone = 'pdb/1AK4/target.izone'
-        self.lzone = 'pdb/1AK4/target.lzone'
+        self.decoy = Path(pdb_folder, '1AK4', '1AK4_5w.pdb')
+        self.ref = Path(pdb_folder, '1AK4', 'target.pdb')
+        self.izone = Path(pdb_folder, '1AK4', 'target.izone')
+        self.lzone = Path(pdb_folder, '1AK4', 'target.lzone')
         self.sim = StructureSimilarity(self.decoy, self.ref)
         # target values are calcualted using scripts from
         # https://github.com/haddocking/BM5-clean

--- a/test/test_superpose.py
+++ b/test/test_superpose.py
@@ -1,14 +1,16 @@
 import os
 import unittest
+from pathlib import Path
 from pdb2sql.superpose import superpose
 
+from . import pdb_folder
 
 class TestSuperpose(unittest.TestCase):
     """Test the superpose functionality"""
 
     def setUp(self):
-        self.pdb1 = 'pdb/1AK4/1AK4_5w.pdb'
-        self.pdb2 = 'pdb/1AK4/1AK4_10w.pdb'
+        self.pdb1 = Path(pdb_folder, '1AK4', '1AK4_5w.pdb')
+        self.pdb2 = Path(pdb_folder, '1AK4', '1AK4_10w.pdb')
 
     def test_superpose(self):
         """Test superpose()"""

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -1,13 +1,15 @@
 import unittest
 import numpy as np
+from pathlib import Path
 from pdb2sql import pdb2sql
 from pdb2sql import transform
 
+from . import pdb_folder
 
 class TestTools(unittest.TestCase):
 
     def setUp(self):
-        self.db = pdb2sql('./pdb/dummy_transform.pdb')
+        self.db = pdb2sql(Path(pdb_folder, 'dummy_transform.pdb'))
         self.xyz = self.db.get('x,y,z')
 
     def test_get_xyz(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from pathlib import Path
 from pdb2sql import fetch
 
 class TestTools(unittest.TestCase):


### PR DESCRIPTION
* Treats `pdbs` in `tests` folder with `Path` from `pathlib`.
* `pytest` now runs from main folder as well as from inside `tests` folder.
* addresses #47 
* all tests have passed in my computer running from both folders.

The only issue I found was with `many2sql` which did not accept `Path` objects, so I used `os.fspath` to convert `Paths` to `str` before. This relates to #30.

Cheers,