### PR TITLE
Fix a bug in StructureSimilarity.py

### DIFF
--- a/pdb2sql/StructureSimilarity.py
+++ b/pdb2sql/StructureSimilarity.py
@@ -574,7 +574,7 @@ class StructureSimilarity(object):
 
         if len(xyz_decoy_B) != len(xyz_ref_B):
             xyz_decoy_B, xyz_ref_B = self.get_identical_atoms(
-                sql_decoy, sql_ref, **kwargs)
+                sql_decoy, sql_ref, chain2, **kwargs)
 
         # detect which chain is the longest
         nA, nB = len(xyz_decoy_A), len(xyz_decoy_B)


### PR DESCRIPTION
In line 577, when trying to call ```self.get_identical_atoms```, the chain ID was not specified, causing StructureSimilarity to crash in case the statement at line 577 would return True.